### PR TITLE
Refactor retrieve dietary requirement

### DIFF
--- a/repository/diet_requirement_repository.py
+++ b/repository/diet_requirement_repository.py
@@ -6,3 +6,21 @@ def get_dietary_requirements(session, user_id):
     if diet_requirement:
         session.expunge(diet_requirement)
     return diet_requirement
+def diet_requirement_to_dict(diet_requirement):
+    if not diet_requirement:
+        return {}
+    return {
+        'diet_id': diet_requirement.diet_id,
+        'user_id': diet_requirement.user_id,
+        'halal': bool(diet_requirement.halal),
+        'vegetarian': bool(diet_requirement.vegetarian),
+        'vegan': bool(diet_requirement.vegan),
+        'nut_allergy': bool(diet_requirement.nut_allergy),
+        'shellfish_allergy': bool(diet_requirement.shellfish_allergy),
+        'gluten_intolerance': bool(diet_requirement.gluten_intolerance),
+        'kosher': bool(diet_requirement.kosher),
+        'lactose_intolerance': bool(diet_requirement.lactose_intolerance),
+        'diabetic': bool(diet_requirement.diabetic),
+        'egg_allergy': bool(diet_requirement.egg_allergy),
+        'other': diet_requirement.other
+    }

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -344,7 +344,6 @@ def get_position_qualification(session, position_id):
     return qualification_id
 
 
-
 # This can be called by api from postman, to test easily
 def test_vehicle_list(session, request_id):
    v_l = get_vehicle_list(session, request_id)

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -366,6 +366,6 @@ def test_vehicle_list(session, request_id):
     # print(get_input_availability(session,360))
     # print(time_unavailability_list(session,31))
     # print(get_input_availability(session,360))
-    #print(get_input_clashes(session,323))
+    # print(get_input_clashes(session,323))
 
    return 1

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -369,3 +369,4 @@ def test_vehicle_list(session, request_id):
     # print(get_input_availability(session,360))
     #print(get_input_clashes(session,request_id))
 
+   return 1

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -348,7 +348,7 @@ def get_position_qualification(session, position_id):
 def test_vehicle_list(session, request_id):
    v_l = get_vehicle_list(session, request_id)
    for v in v_l:
-     get_position_list(session, v)
+      get_position_list(session, v)
 
     # print("get_postion_role", get_position_role(session,720))
     # print("get_APR_matrix", get_input_rolerequirements(session,361))

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -3,17 +3,6 @@ from sqlalchemy import orm, func, alias
 import numpy as np
 import datetime
 
-import pytest
-from domain.base import Session, Engine
-@pytest.fixture
-def session():
-    # 创建一个新的 session
-    new_session = Session(bind=Engine)
-    yield new_session
-
-    # 关闭 session
-    new_session.close()
-
 
 def get_input_A(session, request_id):
     asset_list_count = session.query(AssetRequestVehicle).filter(AssetRequestVehicle.request_id == request_id).count()
@@ -386,36 +375,3 @@ def test_vehicle_list(session, request_id):
     # print(get_input_availability(session,360))
     #print(get_input_clashes(session,request_id))
 
-@pytest.fixture
-def request_id():
-    return '322'
-
-@pytest.fixture
-def vehicle_id():
-    return  '369'
-@pytest.fixture
-def position_id():
-    return
-
-
-def test_get_input_clashes(session,request_id):
-    print(get_input_clashes(session,request_id))
-def test_get_vehicle_time(session,vehicle_id):
-    print(get_vehicle_time(session,vehicle_id))
-def test_get_vehicle_list(session,request_id):
-    print(get_vehicle_list(session,request_id))
-
-def test_get_position_list(session,vehicle_id):
-    print(get_position_list(session,vehicle_id))
-
-def test_get_position_list_all(session,request_id):
-    print(get_position_list_all(session,request_id))
-
-def test_get_position_vehicle(session,position_id):
-    print(get_position_vehicle(session,position_id))
-
-def test_get_position_role(session,position_id):
-    print(get_position_role(session,position_id))
-
-def test_get_position_qualification(session,position_id):
-    print(get_position_qualification(session,position_id))

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -350,7 +350,7 @@ def test_vehicle_list(session, request_id):
    for v in v_l:
      get_position_list(session, v)
 
-    #print("get_postion_role", get_position_role(session,720))
+    # print("get_postion_role", get_position_role(session,720))
     # print("get_APR_matrix", get_input_rolerequirements(session,361))
     # get_position_qualification(session,756)
     # print("get_APQ_matrix",get_input_qualrequirements(session,361))

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -3,6 +3,17 @@ from sqlalchemy import orm, func, alias
 import numpy as np
 import datetime
 
+import pytest
+from domain.base import Session, Engine
+@pytest.fixture
+def session():
+    # 创建一个新的 session
+    new_session = Session(bind=Engine)
+    yield new_session
+
+    # 关闭 session
+    new_session.close()
+
 
 def get_input_A(session, request_id):
     asset_list_count = session.query(AssetRequestVehicle).filter(AssetRequestVehicle.request_id == request_id).count()
@@ -344,13 +355,20 @@ def get_position_qualification(session, position_id):
     return qualification_id
 
 
+
+
+
+
+
+
+
 # This can be called by api from postman, to test easily
 def test_vehicle_list(session, request_id):
-    v_l = get_vehicle_list(session, request_id)
-    for v in v_l:
-        get_position_list(session, v)
+   v_l = get_vehicle_list(session, request_id)
+   for v in v_l:
+     get_position_list(session, v)
 
-    # print("get_postion_role", get_position_role(session,720))
+    #print("get_postion_role", get_position_role(session,720))
     # print("get_APR_matrix", get_input_rolerequirements(session,361))
     # get_position_qualification(session,756)
     # print("get_APQ_matrix",get_input_qualrequirements(session,361))
@@ -366,6 +384,38 @@ def test_vehicle_list(session, request_id):
     # print(get_input_availability(session,360))
     # print(time_unavailability_list(session,31))
     # print(get_input_availability(session,360))
-    # print(get_input_clashes(session,323))
+    #print(get_input_clashes(session,request_id))
 
-    return 1
+@pytest.fixture
+def request_id():
+    return '322'
+
+@pytest.fixture
+def vehicle_id():
+    return  '369'
+@pytest.fixture
+def position_id():
+    return
+
+
+def test_get_input_clashes(session,request_id):
+    print(get_input_clashes(session,request_id))
+def test_get_vehicle_time(session,vehicle_id):
+    print(get_vehicle_time(session,vehicle_id))
+def test_get_vehicle_list(session,request_id):
+    print(get_vehicle_list(session,request_id))
+
+def test_get_position_list(session,vehicle_id):
+    print(get_position_list(session,vehicle_id))
+
+def test_get_position_list_all(session,request_id):
+    print(get_position_list_all(session,request_id))
+
+def test_get_position_vehicle(session,position_id):
+    print(get_position_vehicle(session,position_id))
+
+def test_get_position_role(session,position_id):
+    print(get_position_role(session,position_id))
+
+def test_get_position_qualification(session,position_id):
+    print(get_position_qualification(session,position_id))

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -345,12 +345,6 @@ def get_position_qualification(session, position_id):
 
 
 
-
-
-
-
-
-
 # This can be called by api from postman, to test easily
 def test_vehicle_list(session, request_id):
    v_l = get_vehicle_list(session, request_id)

--- a/services/optimiser/input_processing.py
+++ b/services/optimiser/input_processing.py
@@ -366,6 +366,6 @@ def test_vehicle_list(session, request_id):
     # print(get_input_availability(session,360))
     # print(time_unavailability_list(session,31))
     # print(get_input_availability(session,360))
-    #print(get_input_clashes(session,request_id))
+    #print(get_input_clashes(session,323))
 
    return 1


### PR DESCRIPTION
For this pull request, change data structure of retrive dietary requirement.

Test cases:

1.  when user_id =2

- URL:http://127.0.0.1:5000/dietary/requirements?user_id=2
- Test result 
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/126942292/235421780-7080efe8-ea7f-49a8-869b-bee28cf63f2e.png">

2.  when user_id 3

- URL:http://127.0.0.1:5000/dietary/requirements?user_id=3
- Test result
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/126942292/235421896-67cf81c9-8bf2-42bd-bee8-abb742499780.png">


3.  when user_id =1000

- URL:http://127.0.0.1:5000/dietary/requirements?user_id=10000
- Test result
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/126942292/235422065-be675dbb-0dfc-4f85-a68a-ff884c5e193b.png">


4. when user_id is not a int

- URL :http://127.0.0.1:5000/dietary/requirements?user_id=diet
- Test result
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/126942292/235422192-da7761dd-7ea2-4503-b279-68fe53a32f7f.png">
