### PR TITLE
Fix bugs in dietary requirements refactor

### DIFF
--- a/application.py
+++ b/application.py
@@ -38,7 +38,6 @@ app.register_blueprint(volunteer_unavailability_bp)
 app.register_blueprint(user_bp)
 app.register_blueprint(chatbot_bp)
 app.register_blueprint(diet_requirement_retrieval_bp)
-app.register_blueprint(diet_requirement_bp)
 
 
 

--- a/controllers/diet_requirement.py
+++ b/controllers/diet_requirement.py
@@ -11,7 +11,7 @@ from services.jwk import requires_auth, JWKService
 
 # getting the data from the frontend
 new_parser = reqparse.RequestParser()
-new_parser.add_argument('user_id', type=int, required=True)
+new_parser.add_argument('user_id', type=int)
 new_parser.add_argument('restrictions', type=DietaryRestriction, action='append')
 new_parser.add_argument('custom_restrictions', type=str)
 

--- a/controllers/diet_requirement.py
+++ b/controllers/diet_requirement.py
@@ -15,11 +15,6 @@ new_parser.add_argument('user_id', type=int, required=True)
 new_parser.add_argument('restrictions', type=DietaryRestriction, action='append')
 new_parser.add_argument('custom_restrictions', type=str)
 
-# the result for whether updating the data success
-result_fields = {
-    "result": fields.Boolean
-}
-
 options = [
     'halal',
     'vegetarian',
@@ -34,7 +29,6 @@ options = [
 ]
 
 
-##get the diet requirement from database
 get_parser = reqparse.RequestParser()
 get_parser.add_argument('user_id', type=int, required=True)
 
@@ -54,11 +48,6 @@ diet_requirement_fields = {
     'other': fields.String
 }
 
-result_fields = {
-    "diet_requirement": fields.Nested(diet_requirement_fields),
-    "success": fields.Boolean
-}
-
 
 class DietaryOptions(Resource):
 
@@ -75,7 +64,6 @@ class DietaryRequirement(Resource):
         """
 
     @requires_auth
-    @marshal_with(result_fields)
     def post(self):
         """
         Returns:
@@ -87,7 +75,8 @@ class DietaryRequirement(Resource):
             user_id = JWKService.decode_user_id()
 
             with session_scope() as session:
-                return {'result': save_dietary_requirements(session, user_id, args)}
+                save_dietary_requirements(session, user_id, args)
+                return {'result': True}, 200
         except Exception as e:
             return {'result': False}, 400
 
@@ -100,6 +89,8 @@ class DietaryRequirement(Resource):
             user_id = JWKService.decode_user_id()
             if user_id is None:
                 raise ValueError("user_id is required")
+            elif user_id == -1:
+                raise Exception("An error occurred while decoding the auth token.")
 
             with session_scope() as session:
                 diet_requirement = get_dietary_requirements(session, user_id)

--- a/services/jwk.py
+++ b/services/jwk.py
@@ -33,7 +33,9 @@ class JWKService:
     @staticmethod
     def decode_user_id() -> int:
         try:
-            decoded = jwt.decode(request.headers.get("Authorization"), __secret__, algorithms=["HS256"])
+            data = request.headers.get("Authorization")
+            token = str.replace(str(data), 'Bearer ', '')
+            decoded = jwt.decode(token, __secret__, algorithms=["HS256"])
             return int(decoded.get("sub"))
         except Exception as e:
             return -1


### PR DESCRIPTION
Pull Request #27 introduced broken import to main branch. Removed import because it is not necessary.

Authentication decoding did not work with how Postman creates the bearer token header, added logic to more robustly decode the token.

Dietary requirements POST method was returning dietary requirements object with null fields. Frontend does not need this object returned, so the method now returns only a success field with true or false and a 200/400 code.