### PR TITLE
Refactor @requires_auth and @has_role behaviour when authentication token does not exist

### DIFF
--- a/services/jwk.py
+++ b/services/jwk.py
@@ -69,8 +69,7 @@ def requires_auth(func):
     def wrapper(*args, **kwargs):
         authorization_header = request.headers.get("Authorization")
         if authorization_header is None:
-            # TODO: Throw an error
-            pass
+            return flask_restful.abort(401)
         token = authorization_header[len('Bearer '):]
         if jwkservice.validate(token):
             return func(*args, **kwargs)
@@ -105,8 +104,7 @@ def has_role(*roles):
         def wrapper(*args, **kwargs):
             authorization_header = request.headers.get("Authorization")
             if authorization_header is None:
-                # TODO: Throw an error
-                pass
+                return flask_restful.abort(401)
             token = authorization_header[len('Bearer '):]
             if jwkservice.validate(token) and jwkservice.validate_role(token, roles):
                 return func(*args, **kwargs)


### PR DESCRIPTION
Previous behaviour:
- Code tried to access the length of a null object, and caused a NoneType error

Tested using the `/v2/reference/roles` GET, POST, PATCH and DELETE methods.
Expected behaviour: 
- return 401 with a bad password message
- endpoints are still accessible when the token is included