### PR TITLE
Allow non-supervisor volunteers to fetch data about themselves

### DIFF
--- a/controllers/v2/volunteers/api.py
+++ b/controllers/v2/volunteers/api.py
@@ -1,26 +1,26 @@
 from flask_restful import Resource, marshal_with
 
-from controllers.v2.v2_blueprint import v2_bp, v2_api
+from controllers.v2.v2_blueprint import v2_api
 from controllers.v2.volunteers.response_models import volunteer_listing_model, volunteer_personal_info
 from domain import session_scope, UserType
 from repository.volunteer_repository import list_volunteers, get_volunteer_info
-from services.jwk import requires_auth, has_role
+from services.jwk import requires_auth, has_role, is_user_or_has_role
 
 
 class VolunteerV2(Resource):
 
     @requires_auth
-    @has_role(UserType.ROOT_ADMIN)
     def get(self, user_id=None):
         if user_id:
             @marshal_with(volunteer_personal_info)
-            # TODO: Allow the user to view their personal detail
+            @is_user_or_has_role(user_id, UserType.ROOT_ADMIN)
             def get_personal_info():
                 with session_scope() as session:
                     return get_volunteer_info(session, user_id)
             return get_personal_info()
         else:
             @marshal_with(volunteer_listing_model)
+            @has_role(UserType.ROOT_ADMIN)
             def list_all_volunteers():
                 with session_scope() as session:
                     return list_volunteers(session)


### PR DESCRIPTION
Refactor `/v2/volunteers/<user_id>` such that volunteers can get their own data, but not other volunteers' data. Supervisors can still fetch data for any volunteer.

Added a `@is_user_or_has_role` decorator to achieve this.

Ran all of the `/v2/volunteers` requests in postman.

Method, expected behaviour:
- Get all (supervisor), 200 OK
- Get all (volunteer), 403 Forbidden
- Get all (unauthenticated), no data returned
- Get individual (supervisor), volunteer 8's data returned, 200 OK
- Get individual (volunteer themselves), volunteer 8's data returned, 200 OK
- Get individual (other volunteer), 403 Forbidden